### PR TITLE
Performance and robustness improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ logs/
 
 # Code review files
 /review/
+/archive/

--- a/R/01-demographic.R
+++ b/R/01-demographic.R
@@ -2,23 +2,23 @@
 
 # Load sex variables from relevant sweeps
 sex_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, sex_S1 = W1sexYP),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, sex_S2 = W2SexYP),
-  S3 = read_dta(file.path(data_path, sweeps$S3youngperson)) %>%
+  S3 = ns_data[["S3youngperson"]] %>%
     select(NSID, sex_S3 = W3sexYP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, W4Boost, sex_S4 = W4SexYP),
-  S5 = read_dta(file.path(data_path, sweeps$S5youngperson)) %>%
+  S5 = ns_data[["S5youngperson"]] %>%
     select(NSID, sex_S5 = W5SexYP),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(NSID, sex_S6 = W6Sex),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, sex_S7 = W7Sex),
-  S8 = read_dta(file.path(data_path, sweeps$S8maininterview)) %>%
+  S8 = ns_data[["S8maininterview"]] %>%
     select(NSID, sex_S8 = W8CMSEX),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, sex_S9 = W9DSEX)
 )
 
@@ -100,15 +100,15 @@ sex_all <- sex_all %>%
 # Ethnicity --------------------------------------------------------------------
 # Load ethnicity variables from relevant sweeps
 ethnicity_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, eth_S1 = W1ethnic2YP),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, eth_S2 = W2ethnicYP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, eth_S4 = w4ethnic2YP),
-  S8 = read_dta(file.path(data_path, sweeps$S8derivedvariable)) %>%
+  S8 = ns_data[["S8derivedvariable"]] %>%
     select(NSID, eth_S8 = W8DETHN15),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, eth_S9 = W9DETHN15)
 )
 
@@ -209,13 +209,13 @@ eth_all <- eth_all %>%
 # Language --------------------------------------------------------------------
 # Load relevant language variables
 lang_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, lang_S1 = W1englangYP),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, lang_S2 = W2EnglangYP),
-  S3 = read_dta(file.path(data_path, sweeps$S3familybackground)) %>%
+  S3 = ns_data[["S3familybackground"]] %>%
     select(NSID, lang_S3 = W3englangHH),
-  S4 = read_dta(file.path(data_path, sweeps$S4familybackground)) %>%
+  S4 = ns_data[["S4familybackground"]] %>%
     select(NSID, lang_S4 = W4EngLangHH)
 )
 
@@ -273,17 +273,17 @@ lang_all <- lang_all %>%
 # Sexual Orientation --------------------------------------------------------------------
 # Load sexuality variables
 sexuality_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(NSID, sori19 = W6SexualityYP),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, sori20 = W7SexualityYP),
-  S8 = read_dta(file.path(data_path, sweeps$S8selfcompletion)) %>%
+  S8 = ns_data[["S8selfcompletion"]] %>%
     select(NSID, sori25 = W8SEXUALITY),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, sori32 = W9SORI)
 )
 
@@ -361,15 +361,15 @@ sexuality_all <- sexuality_all %>%
 # Partnership --------------------------------------------------------------------
 # Load partnership variables from relevant sweeps
 partnr_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(NSID, partnr19 = W6MarStatYP),
-  S8 = read_dta(file.path(data_path, sweeps$S8derivedvariable)) %>%
+  S8 = ns_data[["S8derivedvariable"]] %>%
     select(NSID, partnradu25 = W8DMARSTAT),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, partnradu32 = W9DMARSTAT)
 )
 
@@ -476,19 +476,19 @@ partnr_all <- partnr_all %>%
 # Region --------------------------------------------------------------------
 # Load region variables from relevant sweeps
 region_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S2 = read_dta(file.path(data_path, sweeps$S2familybackground)) %>%
+  S2 = ns_data[["S2familybackground"]] %>%
     select(NSID, regub15 = urbind, regov15 = gor),
-  S3 = read_dta(file.path(data_path, sweeps$S3familybackground)) %>%
+  S3 = ns_data[["S3familybackground"]] %>%
     select(NSID, regub16 = urbind, regov16 = gor),
-  S8 = read_dta(file.path(data_path, sweeps$S8derivedvariable)) %>%
+  S8 = ns_data[["S8derivedvariable"]] %>%
     select(NSID, regor25 = W8DGOR),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, regor32 = W9DRGN),
-  S9_2 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9_2 = ns_data[["S9maininterview"]] %>%
     select(NSID, regint32 = W9NATIONRES)
 )
 

--- a/R/02-education.R
+++ b/R/02-education.R
@@ -1,17 +1,17 @@
 # Current Aim Education Own --------------------------------------------------------------------
 # Load education variables from relevant sweeps
 educaim_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, educaim17_raw = w4saim),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(NSID, educaim19_raw = W6Saim),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, educaim20_raw = W7SAim),
-  S8 = read_dta(file.path(data_path, sweeps$S8maininterview)) %>%
+  S8 = ns_data[["S8maininterview"]] %>%
     select(NSID, W8ACTIVITY05, starts_with("W8ACQUC"), starts_with("W8VCQUC")),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, W9ECONACT2, starts_with("W9ACQUC"), starts_with("W9VCQUC"))
 )
 
@@ -184,17 +184,17 @@ educaim_all <- educaim_all %>%
 # Education Own --------------------------------------------------------------------
 # Load education variables from relevant sweeps
 educ_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S8dv = read_dta(file.path(data_path, sweeps$S8derivedvariable)) %>%
+  S8dv = ns_data[["S8derivedvariable"]] %>%
     select(NSID, W8DHANVQH),
-  S8 = read_dta(file.path(data_path, sweeps$S8maininterview)) %>%
+  S8 = ns_data[["S8maininterview"]] %>%
     select(NSID, starts_with("W8VCQU")),
-  S9dv = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9dv = ns_data[["S9derivedvariable"]] %>%
     select(NSID, W9DANVQH, W9DVNVQH),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, starts_with("W9ACQU"), starts_with("W9VCQU"))
 )
 
@@ -410,11 +410,11 @@ educ_all <- educ_all %>%
 # Education Parents --------------------------------------------------------------------
 # Load and rename relevant variables from each sweep
 parent_edu_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1familybackground)) %>%
+  S1 = ns_data[["S1familybackground"]] %>%
     select(NSID, educma_S1 = W1hiqualmum, educpa_S1 = W1hiqualdad),
-  S2 = read_dta(file.path(data_path, sweeps$S2familybackground)) %>%
+  S2 = ns_data[["S2familybackground"]] %>%
     select(NSID, educma_S2 = W2hiqualmum, educpa_S2 = W2hiqualdad),
-  S4 = read_dta(file.path(data_path, sweeps$S4familybackground)) %>%
+  S4 = ns_data[["S4familybackground"]] %>%
     select(NSID, educma_S4 = w4hiqualmum, educpa_S4 = w4hiqualdad)
 )
 

--- a/R/03-socioeconomic.R
+++ b/R/03-socioeconomic.R
@@ -1,17 +1,17 @@
 # Economic Activity --------------------------------------------------------------------
 ecoact_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>% select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>% select(NSID),
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, ecoact17 = W4empsYP),
-  S5 = read_dta(file.path(data_path, sweeps$S5youngperson)) %>%
+  S5 = ns_data[["S5youngperson"]] %>%
     select(NSID, ecoact18 = W5mainactYP),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(NSID, ecoact19 = W6TCurrentAct),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, ecoact20 = W7TCurrentAct),
-  S8 = read_dta(file.path(data_path, sweeps$S8derivedvariable)) %>%
+  S8 = ns_data[["S8derivedvariable"]] %>%
     select(NSID, ecoactadu25 = W8DACTIVITYC),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, ecoactadu32 = W9DACTIVITYC)
 )
 # Merge by NSID
@@ -163,13 +163,13 @@ ecoact_all <- ecoact_all %>%
 # Economic Activity Parents --------------------------------------------------------------------
 # Load & select parental employment variables for Sweeps 1–4
 ecoactDT_parents_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1familybackground)) %>%
+  S1 = ns_data[["S1familybackground"]] %>%
     select(NSID, ecoactdtma14 = W1empsmum, ecoactdtpa14 = W1empsdad),
-  S2 = read_dta(file.path(data_path, sweeps$S2familybackground)) %>%
+  S2 = ns_data[["S2familybackground"]] %>%
     select(NSID, ecoactdtma15 = W2empsmum, ecoactdtpa15 = W2empsdad),
-  S3 = read_dta(file.path(data_path, sweeps$S3familybackground)) %>%
+  S3 = ns_data[["S3familybackground"]] %>%
     select(NSID, ecoactdtma16 = W3empsmum, ecoactdtpa16 = W3empsdad),
-  S4 = read_dta(file.path(data_path, sweeps$S4familybackground)) %>%
+  S4 = ns_data[["S4familybackground"]] %>%
     select(NSID, ecoactdtma17 = w4empsmum, ecoactdtpa17 = w4empsdad)
 )
 
@@ -237,18 +237,18 @@ ecoactDT_parents_all <- ecoactDT_parents_all %>%
 # NS-SEC Own --------------------------------------------------------------------
 # Load NS-SEC variables from relevant sweeps
 nssec_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>% select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>% select(NSID),
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, nssec17 = W4nsseccatYP),
-  S5 = read_dta(file.path(data_path, sweeps$S5youngperson)) %>%
+  S5 = ns_data[["S5youngperson"]] %>%
     select(NSID, nssec18 = W5nsseccatYP),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(NSID, nssec19 = w6nsseccatYP),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, nssec20 = W7NSSECCat),
-  S8 = read_dta(file.path(data_path, sweeps$S8derivedvariable)) %>%
+  S8 = ns_data[["S8derivedvariable"]] %>%
     select(NSID, nssec25 = W8DNSSEC17, ecoactadu25 = W8DACTIVITYC),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, nssec32 = W9NSSEC)
 )
 
@@ -367,15 +367,15 @@ nssec_all <- nssec_all %>%
 # NS-SEC Parents --------------------------------------------------------------------
 # Load and select parental NS-SEC variables from Sweeps 1–5
 nssec_parents_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1familybackground)) %>%
+  S1 = ns_data[["S1familybackground"]] %>%
     select(NSID, nssecma14 = W1nsseccatmum, nssecpa14 = W1nsseccatdad),
-  S2 = read_dta(file.path(data_path, sweeps$S2familybackground)) %>%
+  S2 = ns_data[["S2familybackground"]] %>%
     select(NSID, nssecma15 = W2nsseccatmum, nssecpa15 = W2nsseccatdad),
-  S3 = read_dta(file.path(data_path, sweeps$S3familybackground)) %>%
+  S3 = ns_data[["S3familybackground"]] %>%
     select(NSID, nssecma16 = W3cnsseccatmum, nssecpa16 = W3cnsseccatdad),
-  S4 = read_dta(file.path(data_path, sweeps$S4familybackground)) %>%
+  S4 = ns_data[["S4familybackground"]] %>%
     select(NSID, nssecma17 = w4cnsseccatmum, nssecpa17 = w4cnsseccatdad),
-  S5 = read_dta(file.path(data_path, sweeps$S5familybackground)) %>%
+  S5 = ns_data[["S5familybackground"]] %>%
     select(NSID, nssecma18 = w5Cnsseccatmum, nssecpa18 = w5Cnsseccatdad)
 )
 
@@ -478,23 +478,23 @@ nssec_parents_all <- nssec_parents_all %>%
 # House Ownership --------------------------------------------------------------------
 # Load and select house ownership variables from relevant sweeps
 housing_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1familybackground)) %>%
+  S1 = ns_data[["S1familybackground"]] %>%
     select(NSID, hown14 = W1hous12HH),
-  S2 = read_dta(file.path(data_path, sweeps$S2familybackground)) %>%
+  S2 = ns_data[["S2familybackground"]] %>%
     select(NSID, hown15 = W2Hous12HH),
-  S3 = read_dta(file.path(data_path, sweeps$S3familybackground)) %>%
+  S3 = ns_data[["S3familybackground"]] %>%
     select(NSID, hown16 = W3hous12HH),
-  S4 = read_dta(file.path(data_path, sweeps$S4familybackground)) %>%
+  S4 = ns_data[["S4familybackground"]] %>%
     select(NSID, hown17 = W4Hous12HH),
-  S5 = read_dta(file.path(data_path, sweeps$S5familybackground)) %>%
+  S5 = ns_data[["S5familybackground"]] %>%
     select(NSID, W5Hous12HH, W5Hous12BHH, W5Hous12CHH),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(NSID, W6Hous12YP, W6Hous12bYP, W6Hous12cYP),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, W7Hous12YP, W7Hous12bYP, W7Hous12cYP),
-  S8 = read_dta(file.path(data_path, sweeps$S8maininterview)) %>%
+  S8 = ns_data[["S8maininterview"]] %>%
     select(NSID, hown25 = W8TENURE),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, hown32 = W9DTENURE)
 )
 
@@ -770,11 +770,11 @@ hown_all <- hown_all %>%
 # Income Own + Partner --------------------------------------------------------------------
 # Load and select income variables from relevant sweeps
 income_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>% select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>% select(NSID),
-  S8 = read_dta(file.path(data_path, sweeps$S8derivedvariable)) %>%
+  S1 = ns_data[["S1youngperson"]] %>% select(NSID),
+  S4 = ns_data[["S4youngperson"]] %>% select(NSID),
+  S8 = ns_data[["S8derivedvariable"]] %>%
     select(NSID, inc25 = W8DINCB),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, inc32 = W9DINCB)
 )
 
@@ -850,13 +850,13 @@ income_all <- income_all %>%
 # Income Parents --------------------------------------------------------------------
 # Load and select household income variables
 hh_income_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1familybackground)) %>%
+  S1 = ns_data[["S1familybackground"]] %>%
     select(NSID, incwhh14 = W1GrsswkHH),
-  S2 = read_dta(file.path(data_path, sweeps$S2familybackground)) %>%
+  S2 = ns_data[["S2familybackground"]] %>%
     select(NSID, incwhh15 = W2GrsswkHH),
-  S3 = read_dta(file.path(data_path, sweeps$S3familybackground)) %>%
+  S3 = ns_data[["S3familybackground"]] %>%
     select(NSID, incwhh16 = W3incestw),
-  S4 = read_dta(file.path(data_path, sweeps$S4familybackground)) %>%
+  S4 = ns_data[["S4familybackground"]] %>%
     select(NSID, incwhh17 = w4IncEstW)
 )
 
@@ -1048,13 +1048,13 @@ hh_income_all <- hh_income_all %>%
 # IMD --------------------------------------------------------------------
 # Load IMD variables from relevant sweeps
 imd_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>% select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>% select(NSID),
-  S2 = read_dta(file.path(data_path, sweeps$S2familybackground)) %>%
+  S1 = ns_data[["S1youngperson"]] %>% select(NSID),
+  S4 = ns_data[["S4youngperson"]] %>% select(NSID),
+  S2 = ns_data[["S2familybackground"]] %>%
     select(NSID, imd15 = IMDRSCORE),
-  S3 = read_dta(file.path(data_path, sweeps$S3familybackground)) %>%
+  S3 = ns_data[["S3familybackground"]] %>%
     select(NSID, imd16 = IMDRSCORE),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, imd32 = W9DIMDD)
 )
 

--- a/R/04-health.R
+++ b/R/04-health.R
@@ -1,8 +1,8 @@
 # GHQ --------------------------------------------------------------------
 # Load GHQ-12 derived score and item-level data
 ghq_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>% select(NSID),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>% select(NSID),
+  S2 = ns_data[["S2youngperson"]] %>%
     select(
       NSID,
       ghq15 = W2ghq12scr,
@@ -24,7 +24,7 @@ ghq_vars <- list(
         )
       )
     ),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(
       NSID,
       ghq17 = W4ghq12scr,
@@ -46,13 +46,13 @@ ghq_vars <- list(
         )
       )
     ),
-  S8 = read_dta(file.path(data_path, sweeps$S8selfcompletion)) %>%
+  S8 = ns_data[["S8selfcompletion"]] %>%
     select(NSID, starts_with("W8GHQ12_")),
-  S8_derive = read_dta(file.path(data_path, sweeps$S8derivedvariable)) %>%
+  S8_derive = ns_data[["S8derivedvariable"]] %>%
     select(NSID, ghq25 = W8DGHQSC),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, starts_with("W9GHQ12_")),
-  S9_derive = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9_derive = ns_data[["S9derivedvariable"]] %>%
     select(NSID, ghq32 = W9DGHQSC)
 )
 
@@ -186,13 +186,13 @@ ghq_all <- ghq_all %>%
 # Life Satisfaction --------------------------------------------------------------------
 # Load life satisfaction variables from each sweep
 lsat_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>% select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>% select(NSID),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>% select(NSID),
+  S4 = ns_data[["S4youngperson"]] %>% select(NSID),
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, lsat20 = W7OSatisYP),
-  S8 = read_dta(file.path(data_path, sweeps$S8selfcompletion)) %>%
+  S8 = ns_data[["S8selfcompletion"]] %>%
     select(NSID, lsat25 = W8OSATIS),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, lsat32 = W9OSATIS)
 )
 
@@ -245,11 +245,11 @@ lsat_all <- lsat_all %>%
 # Self-Harm --------------------------------------------------------------------
 # Load S8 self-harm variables
 sharm_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S8 = read_dta(file.path(data_path, sweeps$S8selfcompletion)) %>%
+  S8 = ns_data[["S8selfcompletion"]] %>%
     select(NSID, sharm25_ever = W8HARM, sharm25_freq = W8HARM2)
 )
 
@@ -294,11 +294,11 @@ sharm_all <- sharm_all %>%
 # GAD --------------------------------------------------------------------
 # Load GAD-7 derived score and item-level data
 gad_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, gad32 = W9DGAD2)
 )
 
@@ -330,11 +330,11 @@ gad_all <- gad_all %>%
 # PHQ --------------------------------------------------------------------
 # Load GAD-7 derived score and item-level data
 phq_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, phq32 = W9DPHQ2)
 )
 
@@ -366,11 +366,11 @@ phq_all <- phq_all %>%
 # UCLA Loneliness --------------------------------------------------------------------
 # Load GAD-7 derived score and item-level data
 lon_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, lon32 = W9DLONELINESS)
 )
 
@@ -403,17 +403,17 @@ lon_all <- lon_all %>%
 # Self-Rated General Health --------------------------------------------------------------------
 # Load relevant sweep files and select needed variables
 health_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, ghea15 = W2hea1cYP),
-  S3 = read_dta(file.path(data_path, sweeps$S3youngperson)) %>%
+  S3 = ns_data[["S3youngperson"]] %>%
     select(NSID, ghea16 = W3hea1cYP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, ghea17 = W4Hea1CYP),
-  S8 = read_dta(file.path(data_path, sweeps$S8maininterview)) %>%
+  S8 = ns_data[["S8maininterview"]] %>%
     select(NSID, ghea25 = W8GENA),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, ghea32 = W9HLTHGEN)
 )
 
@@ -564,19 +564,19 @@ health_all <- health_all %>%
 # Long-Term Illness --------------------------------------------------------------------
 # Load relevant sweep files and select needed variables
 long_term_illness_files <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, lsi14 = W1chea1HS),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, lsi15 = W2chea1HS),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, lsi17 = W4Hea2YP),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(NSID, lsi19 = W6HealthYP),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, lsi20 = W7HealthYP),
-  S8 = read_dta(file.path(data_path, sweeps$S8maininterview)) %>%
+  S8 = ns_data[["S8maininterview"]] %>%
     select(NSID, lsi25 = W8LOIL),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, lsi32 = W9LOIL)
 )
 

--- a/R/05-anthropometric.R
+++ b/R/05-anthropometric.R
@@ -1,13 +1,13 @@
 # Weight --------------------------------------------------------------------
 # Load weight variables from each sweep
 wt_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S12history)) %>%
+  S1 = ns_data[["S12history"]] %>%
     select(NSID, wt0 = bwtkg),
-  S4 = read_dta(file.path(data_path, sweeps$S4history)) %>%
+  S4 = ns_data[["S4history"]] %>%
     select(NSID, wt0 = W4bwtkgYP),
-  S8 = read_dta(file.path(data_path, sweeps$S8maininterview)) %>%
+  S8 = ns_data[["S8maininterview"]] %>%
     select(NSID, wt25 = W8WEIGHT),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, wt32 = W9WEIGHT)
 )
 
@@ -65,13 +65,13 @@ wt_all <- wt_all %>%
 # Height --------------------------------------------------------------------
 # Load height data from sweeps 8 and 9
 ht_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S8 = read_dta(file.path(data_path, sweeps$S8maininterview)) %>%
+  S8 = ns_data[["S8maininterview"]] %>%
     select(NSID, ht25 = W8HEIGHT),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, ht32 = W9HEIGHT)
 )
 
@@ -122,13 +122,13 @@ ht_all <- ht_all %>%
 # BMI --------------------------------------------------------------------
 # Load BMI data from relevant sweeps
 bmi_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S8 = read_dta(file.path(data_path, sweeps$S8derivedvariable)) %>%
+  S8 = ns_data[["S8derivedvariable"]] %>%
     select(NSID, bmi25 = W8DBMI),
-  S9 = read_dta(file.path(data_path, sweeps$S9derivedvariable)) %>%
+  S9 = ns_data[["S9derivedvariable"]] %>%
     select(NSID, bmi32 = W9DBMI)
 )
 

--- a/R/06-behaviour.R
+++ b/R/06-behaviour.R
@@ -1,17 +1,17 @@
 # Smoke --------------------------------------------------------------------
 # Load smoking data from relevant sweeps
 smoking_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, smknw14 = W1cignowYP, smk14 = W1cigfreqYP),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, smknw15 = W2cignowYP, smk15 = W2cigfreqYP),
-  S3 = read_dta(file.path(data_path, sweeps$S3youngperson)) %>%
+  S3 = ns_data[["S3youngperson"]] %>%
     select(NSID, smknw16 = W3cignowYP, smk16 = W3cigfreqYP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
-  S8 = read_dta(file.path(data_path, sweeps$S8selfcompletion)) %>%
+  S8 = ns_data[["S8selfcompletion"]] %>%
     select(NSID, smk25 = W8SMOKING),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, smk32 = W9SMOKING)
 )
 
@@ -144,26 +144,26 @@ smoking_all <- smoking_all %>%
 # Alcohol --------------------------------------------------------------------
 # Load and Select Variables
 alc_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(
       NSID,
       alcever_S1 = W1alceverYP,
       alcmon_S1 = W1alcmonYP,
       alcfreq_S1 = W1alcfreqYP
     ),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, alcever_S2 = W2alceverYP, alcfreq_S2 = W2alcfreqYP),
-  S3 = read_dta(file.path(data_path, sweeps$S3youngperson)) %>%
+  S3 = ns_data[["S3youngperson"]] %>%
     select(NSID, alcever_S3 = W3alceverYP, alcfreq_S3 = W3alcfreqYP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, alcever_S4 = W4AlcEverYP, alcfreq_S4 = W4AlcFreqYP),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(NSID, alcever_S6 = W6AlcEverYP, alcfreq_S6 = W6AlcFreqYP),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, alcever_S7 = W7AlcEverYP, alcfreq_S7 = W7AlcFreqYP),
-  S8 = read_dta(file.path(data_path, sweeps$S8selfcompletion)) %>%
+  S8 = ns_data[["S8selfcompletion"]] %>%
     select(NSID, audita25 = W8AUDIT1, auditb25 = W8AUDIT2, auditc25 = W8AUDIT6),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, audita32 = W9AUDIT1, auditb32 = W9AUDIT2, auditc32 = W9AUDIT3)
 )
 
@@ -424,15 +424,15 @@ alc_all_clean <- alc_all %>%
 # Drug Use --------------------------------------------------------------------
 # Load drug use data from relevant sweeps
 drug_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, canevr14 = W1canntryYP),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, canevr15 = W2canntryYP),
-  S3 = read_dta(file.path(data_path, sweeps$S3youngperson)) %>%
+  S3 = ns_data[["S3youngperson"]] %>%
     select(NSID, canevr16 = W3canntryYP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, canevr17 = W4CannTryYP),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(
       NSID,
       canevr19 = W6DrugYP0a,
@@ -440,7 +440,7 @@ drug_vars <- list(
       now_cann19 = W6DrugOftenYP0a,
       now_oth19 = W6DrugOftenYP0b
     ),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(
       NSID,
       canevr20 = W7DrugYP1YP0a,
@@ -448,7 +448,7 @@ drug_vars <- list(
       now_cann20 = W7DrugOftenYP0a,
       now_oth20 = starts_with("W7DrugOftenYP0")
     ),
-  S8 = read_dta(file.path(data_path, sweeps$S8selfcompletion)) %>%
+  S8 = ns_data[["S8selfcompletion"]] %>%
     select(
       NSID,
       canevr25 = W8DRUGYP10A,
@@ -458,7 +458,7 @@ drug_vars <- list(
       now_cann25 = W8DRUGOFTEN0A,
       now_oth25 = starts_with("W8DRUGOFTEN0")
     ),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(
       NSID,
       canevr32 = W9DRUGYP10A,
@@ -724,19 +724,19 @@ drug_final <- drug_all %>%
 # Exercise --------------------------------------------------------------------
 # Load relevant sweep files and select variables
 exercise_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, spt14 = W1sportYP),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, spt15 = W2sportYP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, spt17 = W4SportYP),
-  S6 = read_dta(file.path(data_path, sweeps$S6youngperson)) %>%
+  S6 = ns_data[["S6youngperson"]] %>%
     select(NSID, spt19 = W6SportYP),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, spt20 = W7SportYP),
-  S8 = read_dta(file.path(data_path, sweeps$S8maininterview)) %>%
+  S8 = ns_data[["S8maininterview"]] %>%
     select(NSID, spt25 = W8EXERCISE),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(NSID, spt32 = W9EXERCISEH)
 )
 
@@ -810,13 +810,13 @@ spt_all <- spt_all %>%
 # Absence --------------------------------------------------------------------
 # Load relevant sweep files and select variables
 absence_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, abs1m14 = W1abs1myMP),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, abs1m15 = W2abs1myMP),
-  S3 = read_dta(file.path(data_path, sweeps$S3youngperson)) %>%
+  S3 = ns_data[["S3youngperson"]] %>%
     select(NSID, abs1m16 = W3abs1myMP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID)
 )
 
@@ -865,13 +865,13 @@ absence_all <- absence_all %>%
 # Suspended/Expelled --------------------------------------------------------------------
 # Load suspension and expulsion variables from each sweep
 suspend_expel_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, susp14 = W1suspendMP, expl14 = W1expelMP),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, susp15 = W2SuspendMP, expl15 = W2ExpelMP),
-  S3 = read_dta(file.path(data_path, sweeps$S3youngperson)) %>%
+  S3 = ns_data[["S3youngperson"]] %>%
     select(NSID, susp16 = W3suspendMP, expl16 = W3expelMP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, expl17 = W4Expel1YP, susp17 = W4Expel2YP)
 )
 
@@ -925,13 +925,13 @@ suspend_expel_all <- suspend_expel_all %>%
 # Truancy --------------------------------------------------------------------
 # Load original variables from S1–S4
 truancy_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, trua14_ever = W1truantYP, trua14_type = W1truant1YP),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, trua15_ever = W2truantYP, trua15_type = W2truant1YP),
-  S3 = read_dta(file.path(data_path, sweeps$S3youngperson)) %>%
+  S3 = ns_data[["S3youngperson"]] %>%
     select(NSID, trua16_ever = W3truantYP, trua16_type = W3truant1YP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, trua17_raw = W4TruantYP)
 )
 
@@ -1005,15 +1005,15 @@ truancy_all <- truancy_all %>%
 # Police Contact --------------------------------------------------------------------
 # Load data for police contact
 police_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, pol14 = W1Police1MP, polcnt14 = W1police2MP),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, pol15 = W2police1MP, polcnt15 = W2Police2MP),
-  S3 = read_dta(file.path(data_path, sweeps$S3youngperson)) %>%
+  S3 = ns_data[["S3youngperson"]] %>%
     select(NSID, pol16 = W3police1MP, polcnt16 = W3police2MP),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(NSID, pol17 = W4Police1MP, polcnt17 = W4Police2MP),
-  S8 = read_dta(file.path(data_path, sweeps$S8selfcompletion)) %>%
+  S8 = ns_data[["S8selfcompletion"]] %>%
     select(
       NSID,
       polwrn25 = W8CJSCONTACT0A,
@@ -1022,7 +1022,7 @@ police_vars <- list(
       polglt25 = W8CJSCONTACT0D,
       polpnd25 = W8CJSCONTACT0E
     ),
-  S9 = read_dta(file.path(data_path, sweeps$S9maininterview)) %>%
+  S9 = ns_data[["S9maininterview"]] %>%
     select(
       NSID,
       polwrn32 = W9CJSCONTACT0A,
@@ -1212,13 +1212,13 @@ police_all <- police_all %>%
 # Bully --------------------------------------------------------------------
 # Load and harmonise bullying variables across sweeps 1–4, 7–8
 bully_vars <- list(
-  S1 = read_dta(file.path(data_path, sweeps$S1youngperson)) %>%
+  S1 = ns_data[["S1youngperson"]] %>%
     select(NSID, bul14 = W1bulrc),
-  S2 = read_dta(file.path(data_path, sweeps$S2youngperson)) %>%
+  S2 = ns_data[["S2youngperson"]] %>%
     select(NSID, bul15 = W2bulrc),
-  S3 = read_dta(file.path(data_path, sweeps$S3youngperson)) %>%
+  S3 = ns_data[["S3youngperson"]] %>%
     select(NSID, bul16 = W3bulrc),
-  S4 = read_dta(file.path(data_path, sweeps$S4youngperson)) %>%
+  S4 = ns_data[["S4youngperson"]] %>%
     select(
       NSID,
       bul17_1 = W4V1perSYP,
@@ -1228,9 +1228,9 @@ bully_vars <- list(
       bul17_5 = W4MadegiveYP,
       bul17_6 = W4NamesYP
     ),
-  S7 = read_dta(file.path(data_path, sweeps$S7youngperson)) %>%
+  S7 = ns_data[["S7youngperson"]] %>%
     select(NSID, starts_with("W7BullyTypeYP0")),
-  S8 = read_dta(file.path(data_path, sweeps$S8selfcompletion)) %>%
+  S8 = ns_data[["S8selfcompletion"]] %>%
     select(NSID, starts_with("W8BULLYTYPE0"))
 )
 


### PR DESCRIPTION
This PR applies a final set of performance- and safety-focused changes to the derived-variables workflow. Computation time has been reduced from around 25 minutes to about 15 seconds on my machine. Although we had agreed to prioritise logic rather than efficiency, the previous runtime made it impractical to iterate on the logic and re-run the pipeline repeatedly, and would have slowed down the logic review.

With these changes, I am satisfied that the revised code runs quickly and reliably enough to progress into the logic review, which I have now started. Further performance or structural changes will only be introduced where they are directly tied to logic changes.

**Changes include:**

1. **Avoid repeated imports from disk**  
The NS datasets are now imported once and then reused, rather than calling `read_dta()` repeatedly whenever extracting a new variable.

2. **Replace `rowwise()` with vectorised code in two functions**  
Two helper functions that previously relied on `dplyr::rowwise()` have been rewritten using vectorised operations. The intent and outputs of these functions are unchanged; the change is purely to reduce computation time.