### PR TITLE
Code review: 01-demographic.R

### DIFF
--- a/R/01-demographic.R
+++ b/R/01-demographic.R
@@ -34,52 +34,52 @@ sex_vars <- list(
 # Merge all sweeps by NSID
 sex_all <- reduce(sex_vars, full_join, by = "NSID")
 
-# Harmonised the missing values for S1-7
+# Harmonise the missing values for S1-7
 # Vector of S1–S7 variable names
 sex_vars_s1_s7 <- paste0("sex_S", 1:7)
 
 # Apply custom recode to S1–S7
 sex_all <- sex_all %>%
-  mutate(across(
-    all_of(sex_vars_s1_s7),
-    ~ case_when(
-      .x == -92 ~ -9,
-      .x == -91 ~ -1,
-      .x == -99 ~ -3,
-      TRUE ~ .x
+  mutate(
+    across(
+      all_of(sex_vars_s1_s7),
+      ~ case_when(
+        .x == -92 ~ -9,
+        .x == -91 ~ -1,
+        .x == -99 ~ -3,
+        .default = .x
+      )
     )
-  ))
+  )
 
-# Derive harmonised sex
+# Harmonise sex: prefer self-report at S9, else taken from other sweeps in order S1 -> S9.
 sex_all <- sex_all %>%
   mutate(
     # First pass: positive values only
     sex_final_main = case_when(
-      !is.na(sex_S9) & sex_S9 > 0 ~ sex_S9,
-      !is.na(sex_S1) & sex_S1 > 0 ~ sex_S1,
-      !is.na(sex_S2) & sex_S2 > 0 ~ sex_S2,
-      !is.na(sex_S3) & sex_S3 > 0 ~ sex_S3,
-      !is.na(sex_S4) & sex_S4 > 0 & W4Boost == 2 ~ sex_S4, # main
-      !is.na(sex_S4) & sex_S4 > 0 & W4Boost == 1 ~ sex_S4, # boost
-      !is.na(sex_S5) & sex_S5 > 0 ~ sex_S5,
-      !is.na(sex_S6) & sex_S6 > 0 ~ sex_S6,
-      !is.na(sex_S7) & sex_S7 > 0 ~ sex_S7,
-      !is.na(sex_S8) & sex_S8 > 0 ~ sex_S8,
-      TRUE ~ NA_real_
+      sex_S9 > 0 ~ sex_S9,
+      sex_S1 > 0 ~ sex_S1,
+      sex_S2 > 0 ~ sex_S2,
+      sex_S3 > 0 ~ sex_S3,
+      sex_S4 > 0 ~ sex_S4,
+      sex_S5 > 0 ~ sex_S5,
+      sex_S6 > 0 ~ sex_S6,
+      sex_S7 > 0 ~ sex_S7,
+      sex_S8 > 0 ~ sex_S8,
+      .default = NA
     ),
-
-    # Second pass: fallback to non-positive values (< 0)
+    # Otherwise first non‑substantive (<1) from S1–S8
     sex_final = case_when(
       !is.na(sex_final_main) ~ sex_final_main,
-      !is.na(sex_S1) & sex_S1 < 1 ~ sex_S1,
-      !is.na(sex_S2) & sex_S2 < 1 ~ sex_S2,
-      !is.na(sex_S3) & sex_S3 < 1 ~ sex_S3,
-      !is.na(sex_S4) & sex_S4 < 1 ~ sex_S4,
-      !is.na(sex_S5) & sex_S5 < 1 ~ sex_S5,
-      !is.na(sex_S6) & sex_S6 < 1 ~ sex_S6,
-      !is.na(sex_S7) & sex_S7 < 1 ~ sex_S7,
-      !is.na(sex_S8) & sex_S8 < 1 ~ sex_S8,
-      TRUE ~ NA_real_
+      sex_S1 < 1 ~ sex_S1,
+      sex_S2 < 1 ~ sex_S2,
+      sex_S3 < 1 ~ sex_S3,
+      sex_S4 < 1 ~ sex_S4,
+      sex_S5 < 1 ~ sex_S5,
+      sex_S6 < 1 ~ sex_S6,
+      sex_S7 < 1 ~ sex_S7,
+      sex_S8 < 1 ~ sex_S8,
+      .default = NA
     )
   )
 
@@ -92,15 +92,14 @@ sex_all <- sex_all %>%
     )
   ) %>%
   mutate(
-    sex = factor(
+    sex = haven::labelled(
       sex,
-      levels = c(0, 1, -1, -3, -9),
       labels = c(
-        "male",
-        "female",
-        "Item not applicable",
-        "Not asked at the fieldwork stage/participated/interviewed",
-        "Refusal"
+        "Male" = 0L,
+        "Female" = 1L,
+        "Item not applicable" = -1L,
+        "Not asked at the fieldwork stage/participated/interviewed" = -3L,
+        "Refusal" = -9L
       )
     )
   ) %>%
@@ -130,89 +129,70 @@ eth_vars <- c("eth_S1", "eth_S2", "eth_S4")
 
 # Apply the recoding (recode missing values in Sweeps 1-4)
 eth_all <- eth_all %>%
-  mutate(across(
-    all_of(eth_vars),
-    ~ case_when(
-      .x == -999 ~ -2,
-      .x == -998 ~ -2,
-      .x == -997 ~ -2,
-      .x == -99 ~ -3,
-      .x == -94 ~ -2,
-      .x == -92 ~ -9,
-      .x == -91 ~ -1,
-      .x == -1 ~ -8,
-      TRUE ~ .x
+  mutate(
+    across(
+      all_of(eth_vars),
+      ~ case_when(
+        .x %in% -999:-997 ~ -2,
+        .x == -99 ~ -3,
+        .x == -94 ~ -8,
+        .x == -92 ~ -9,
+        .x == -91 ~ -1,
+        .x == -1 ~ -8,
+        .default = .x
+      )
     )
-  ))
+  )
 
 # Derive ethnicity: use S1 if available, else later
 eth_all <- eth_all %>%
   mutate(
     eth = case_when(
-      !is.na(eth_S1) & eth_S1 > 0 ~ eth_S1,
-      !is.na(eth_S2) & eth_S2 > 0 ~ eth_S2,
-      !is.na(eth_S4) & eth_S4 > 0 ~ eth_S4,
-      !is.na(eth_S8) & eth_S8 > 0 ~ eth_S8,
-      !is.na(eth_S9) & eth_S9 > 0 ~ eth_S9,
-      !is.na(eth_S1) & eth_S1 < 1 ~ eth_S1,
-      !is.na(eth_S2) & eth_S2 < 1 ~ eth_S2,
-      !is.na(eth_S4) & eth_S4 < 1 ~ eth_S4,
-      !is.na(eth_S8) & eth_S8 < 1 ~ eth_S8,
-      !is.na(eth_S9) & eth_S9 < 1 ~ eth_S9,
+      eth_S1 > 0 ~ eth_S1,
+      eth_S2 > 0 ~ eth_S2,
+      eth_S4 > 0 ~ eth_S4,
+      eth_S8 > 0 ~ eth_S8,
+      eth_S9 > 0 ~ eth_S9,
+      eth_S1 < 1 ~ eth_S1,
+      eth_S2 < 1 ~ eth_S2,
+      eth_S4 < 1 ~ eth_S4,
+      eth_S8 < 1 ~ eth_S8,
+      eth_S9 < 1 ~ eth_S9,
       TRUE ~ -3 # Not interviewed/present
     )
-  ) %>%
+  )
+
+eth_labels_substantive <- c(
+  "White-British" = 1L,
+  "White-Irish" = 2L,
+  "Any other White background" = 3L,
+  "Mixed-White and Black Caribbean" = 4L,
+  "Mixed-White and Black African" = 5L,
+  "Mixed-White and Asian" = 6L,
+  "Any other Mixed background" = 7L,
+  "Asian or Asian British-Indian" = 8L,
+  "Asian or Asian British-Pakistani" = 9L,
+  "Asian or Asian British-Bangladeshi" = 10L,
+  "Any other Asian background" = 11L,
+  "Black or Black British-Caribbean" = 12L,
+  "Black or Black British-African" = 13L,
+  "Any other Black background" = 14L,
+  "Chinese" = 15L,
+  "Any other background" = 16L
+)
+
+eth_all <- eth_all |>
   mutate(
-    eth = factor(
+    eth = as.integer(eth),
+    eth = labelled(
       eth,
-      levels = c(
-        1,
-        2,
-        3,
-        4,
-        5,
-        6,
-        7,
-        8,
-        9,
-        10,
-        11,
-        12,
-        13,
-        14,
-        15,
-        16,
-        -1,
-        -2,
-        -3,
-        -8,
-        -9
-      ),
       labels = c(
-        "White-British",
-        "White-Irish",
-        "Any other White background",
-        "Mixed-White and Black Caribbean",
-        "Mixed-White and Black African",
-        "Mixed-White and Asian",
-        "Any other Mixed background",
-        "Asian or Asian British-Indian",
-        "Asian or Asian British-Pakistani",
-        "Asian or Asian British-Bangladeshi",
-        "Any other Asian background",
-        "Black or Black British-Caribbean",
-        "Black or Black British-African",
-        "Any other Black background",
-        "Chinese",
-        "Any other background",
-        "Item not applicable",
-        "Script error/information lost",
-        "Not asked at the fieldwork stage/participated/interviewed",
-        "Don’t know/insufficient information",
-        "Refusal"
+        eth_labels_substantive,
+        # only the missing codes actually used for this variable
+        common_missing_labels
       )
     )
-  ) %>%
+  ) |>
   select(NSID, eth)
 
 # Language --------------------------------------------------------------------
@@ -245,35 +225,35 @@ lang_all <- lang_all %>%
     )
   ))
 
+# Final value labels
+lang_labels_substantive <- c(
+  "English only" = 1L,
+  "English first/main and speaks other languages" = 2L,
+  "Another language is respondent’s first or main language" = 3L,
+  "Bilingual" = 4L
+)
+
 # Derive final language variable: use S1, else S2, else S4
 lang_all <- lang_all %>%
   mutate(
     lang = case_when(
-      !is.na(lang_S1) & lang_S1 > 0 ~ lang_S1,
-      !is.na(lang_S2) & lang_S2 > 0 ~ lang_S2,
-      !is.na(lang_S3) & lang_S3 > 0 ~ lang_S3,
-      !is.na(lang_S4) & lang_S4 > 0 ~ lang_S4,
-      !is.na(lang_S1) & lang_S1 < 1 ~ lang_S1,
-      !is.na(lang_S2) & lang_S2 < 1 ~ lang_S2,
-      !is.na(lang_S3) & lang_S3 < 1 ~ lang_S3,
-      !is.na(lang_S4) & lang_S4 < 1 ~ lang_S4,
+      lang_S1 > 0 ~ lang_S1,
+      lang_S2 > 0 ~ lang_S2,
+      lang_S3 > 0 ~ lang_S3,
+      lang_S4 > 0 ~ lang_S4,
+      lang_S1 < 1 ~ lang_S1,
+      lang_S2 < 1 ~ lang_S2,
+      lang_S3 < 1 ~ lang_S3,
+      lang_S4 < 1 ~ lang_S4,
       TRUE ~ -3 # Not interviewed/present
     )
   ) %>%
   mutate(
-    lang = factor(
-      lang,
-      levels = c(1, 2, 3, 4, -1, -2, -3, -8, -9),
+    lang = labelled(
+      as.integer(lang),
       labels = c(
-        "English only",
-        "English first/main and speaks other languages",
-        "Another language is respondent’s first or main language",
-        "Bilingual",
-        "Item not applicable",
-        "Script error/information lost",
-        "Not asked at the fieldwork stage/participated/interviewed",
-        "Don’t know/insufficient information",
-        "Refusal"
+        lang_labels_substantive,
+        common_missing_labels
       )
     )
   ) %>%
@@ -299,6 +279,14 @@ sexuality_vars <- list(
 # Merge by ID
 sexuality_all <- reduce(sexuality_vars, full_join, by = "NSID")
 
+# Labels
+sexuality_labels_substantive <- c(
+  "Heterosexual/straight" = 1L,
+  "Gay/lesbian" = 2L,
+  "Bisexual" = 3L,
+  "Other" = 4L
+)
+
 # recode missing values and response categories
 sexuality_all <- sexuality_all %>%
   mutate(
@@ -307,9 +295,10 @@ sexuality_all <- sexuality_all %>%
       sori19 == 2 ~ 2,
       sori19 == 3 ~ 3,
       sori19 == 4 ~ 4,
-      sori19 %in% c(-100, -97, -3) ~ -3,
-      sori19 %in% c(-92, -9) ~ -9,
-      sori19 %in% c(-91, -1, -8) ~ -8,
+      sori19 == -3 ~ -3,
+      sori19 %in% c(-92, -9, -100, -97) ~ -9,
+      sori19 %in% c(-1, -8) ~ -8,
+      sori19 == -91 ~ -1, # Not applicable
       sori19 %in% c(-999, -998, -997, -94) ~ -2,
       TRUE ~ -3
     ),
@@ -318,9 +307,10 @@ sexuality_all <- sexuality_all %>%
       sori20 == 2 ~ 2,
       sori20 == 3 ~ 3,
       sori20 == 4 ~ 4,
-      sori20 %in% c(-100, -97, -3) ~ -3,
-      sori20 %in% c(-92, -9) ~ -9,
-      sori20 %in% c(-91, -1, -8) ~ -8,
+      sori20 == -3 ~ -3, # Check: 100 stands for 'Respondent declined sexual experience Qs', -97: Refused self-completion, this maps them onto 'Not asked (...)' instead of 'Refused'
+      sori20 %in% c(-92, -9, -100, -97) ~ -9,
+      sori20 %in% c(-1, -8) ~ -8,
+      sori20 == -91 ~ -1, # Not applicable
       sori20 %in% c(-999, -998, -997, -94) ~ -2,
       TRUE ~ -3
     ),
@@ -331,7 +321,7 @@ sexuality_all <- sexuality_all %>%
       sori25 == 4 ~ 4,
       sori25 == -9 ~ -9,
       sori25 == -8 ~ -8,
-      sori25 == -1 ~ -8,
+      sori25 == -1 ~ -1, # Not applicable
       TRUE ~ -3
     ),
     sori32 = case_when(
@@ -341,33 +331,28 @@ sexuality_all <- sexuality_all %>%
       sori32 == 4 ~ 4,
       sori32 == 5 ~ -7,
       sori32 == -9 ~ -9,
-      sori32 %in% c(-8, -1) ~ -8,
+      sori32 %in% c(-8) ~ -8,
       sori32 == -3 ~ -3,
+      sori32 == -1 ~ -1, # Not applicable
       TRUE ~ -3
     )
   ) %>%
-  mutate(across(
-    starts_with("sori"),
-    ~ factor(
-      .x,
-      levels = c(1, 2, 3, 4, -1, -2, -3, -7, -8, -9),
-      labels = c(
-        "Heterosexual/straight",
-        "Gay/lesbian",
-        "Bisexual",
-        "Other",
-        "Item not applicable",
-        "Script error/information lost",
-        "Not asked at the fieldwork stage/participated/interviewed",
-        "Prefer not to say",
-        "Don’t know/insufficient information",
-        "Refusal"
+  mutate(
+    across(
+      starts_with("sori"),
+      ~ labelled(
+        as.integer(.x),
+        labels = c(
+          sexuality_labels_substantive,
+          common_missing_labels
+        )
       )
     )
-  )) %>%
+  ) %>%
   select(NSID, sori19, sori20, sori25, sori32)
 
 # Partnership --------------------------------------------------------------------
+
 # Load partnership variables from relevant sweeps
 partnr_vars <- list(
   S1 = ns_data[["S1youngperson"]] %>%
@@ -375,111 +360,147 @@ partnr_vars <- list(
   S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
   S6 = ns_data[["S6youngperson"]] %>%
-    select(NSID, partnr19 = W6MarStatYP),
+    select(NSID, partnr19_orig = W6MarStatYP),
   S8 = ns_data[["S8derivedvariable"]] %>%
-    select(NSID, partnradu25 = W8DMARSTAT),
+    select(NSID, partnradu25_orig = W8DMARSTAT),
   S9 = ns_data[["S9derivedvariable"]] %>%
-    select(NSID, partnradu32 = W9DMARSTAT)
+    select(NSID, partnradu32_orig = W9DMARSTAT)
 )
 
 # Merge all sweeps by ID
 partnr_all <- reduce(partnr_vars, full_join, by = "NSID")
 
-# recode missing values and response categories
-partnr_all <- partnr_all %>%
+## Complete version --------------------------------------------------------------------
+
+# Look up tables for simpler re-coding
+partnradu25_lookup <- tibble::tribble(
+  ~old_label                            , ~new_value , ~new_label                              ,
+  # missing
+  "Refused"                             , -9L        , "Refusal"                               ,
+  "Insufficient information"            , -8L        , "Don't know / insufficient information" ,
+  "Not applicable"                      , -1L        , "Item not applicable"                   ,
+  # substantive 0–8
+  "Single and never married or in a CP" ,  0L        , "Single, never married / in CP"         ,
+  "Married"                             ,  1L        , "Married"                               ,
+  "Separated but still legally married" ,  2L        , "Separated, still legally married"      ,
+  "Divorced"                            ,  3L        , "Divorced"                              ,
+  "Widowed"                             ,  4L        , "Widowed"                               ,
+  "A Civil Partner"                     ,  5L        , "Civil partner"                         ,
+  "Separated but still legally in a CP" ,  6L        , "Separated, still legally in CP"        ,
+  "A former Civil Partner"              ,  7L        , "Former civil partner"                  ,
+  "A surviving Civil Partner"           ,  8L        , "Surviving civil partner"
+)
+
+partnradu32_lookup <- tibble::tribble(
+  ~old_label                                                           , ~new_value , ~new_label                              ,
+  # missing
+  "Refused"                                                            , -9L        , "Refusal"                               ,
+  "Insufficient information"                                           , -8L        , "Don't know / insufficient information" ,
+  # substantive 0–8
+  "Single that is never married or never in a Civil Partnership"       ,  0L        , "Single, never married / in CP"         ,
+  "Married"                                                            ,  1L        , "Married"                               ,
+  "Legally separated"                                                  ,  2L        , "Separated, still legally married"      ,
+  "Divorced"                                                           ,  3L        , "Divorced"                              ,
+  "Widowed"                                                            ,  4L        , "Widowed"                               ,
+  "A Civil Partner in a legally recognised Civil Partnership"          ,  5L        , "Civil partner"                         ,
+  "A former Civil Partner (where Civil Partnership legally dissolved)" ,  7L        , "Former civil partner"                  ,
+  "A surviving Civil Partner (where Civil Partner has died)"           ,  8L        , "Surviving civil partner"
+)
+
+# Re-code through look up tables
+partnr_all <- partnr_all |>
   mutate(
-    partnr19 = case_when(
-      partnr19 > 0 ~ partnr19 - 1,
-      partnr19 == -92 ~ -9,
-      partnr19 == -91 ~ -1,
-      partnr19 == -1 ~ -8,
-      partnr19 %in% c(-997, -97) ~ -3,
-      TRUE ~ -3
+    partnradu25 = recode_labelled_by_labels(
+      partnradu25_orig,
+      partnradu25_lookup,
+      na_to = -3, # All uncoded NAs -> -3
+      na_label = "Not asked at the fieldwork stage/participated/interviewed" # Label for NAs
     ),
-    partnr25 = case_when(
-      partnradu25 == 1 ~ 0,
-      partnradu25 %in% c(2, 6) ~ 1,
-      partnradu25 %in% c(3, 7) ~ 2,
-      partnradu25 %in% c(4, 8) ~ 3,
-      partnradu25 %in% c(5, 9) ~ 4,
-      partnradu25 == -9 ~ -9,
-      partnradu25 == -8 ~ -8,
-      partnradu25 == -1 ~ -1,
-      TRUE ~ -3
-    ),
-    partnr32 = case_when(
-      partnradu32 == 1 ~ 0,
-      partnradu32 %in% c(2, 6) ~ 1,
-      partnradu32 %in% c(3, 7) ~ 2,
-      partnradu32 %in% c(4, 8) ~ 3,
-      partnradu32 %in% c(5, 9) ~ 4,
-      partnradu32 == -9 ~ -9,
-      partnradu32 == -8 ~ -8,
-      partnradu32 == -1 ~ -1,
-      TRUE ~ -3
+    partnradu32 = recode_labelled_by_labels(
+      partnradu32_orig,
+      partnradu32_lookup,
+      na_to = -3,
+      na_label = "Not asked at the fieldwork stage/participated/interviewed"
     )
   )
 
-# Derive adult partnership variables detailed response categories (age 25 and 32)
+# Cross-tab checks
+partnr_all |>
+  count(partnradu25_orig, partnradu25)
+
+partnr_all |>
+  count(partnradu32_orig, partnradu32)
+
+## Simple version --------------------------------------------------------------------
+
+# Shared look up for recoding complete -> simple partnradu25 and partnradu32
+partnr_simple_lookup <- tibble::tribble(
+  ~old_label                              , ~new_value , ~new_label                                 ,
+  "Refusal"                               , -9L        , "Refusal"                                  ,
+  "Don't know / insufficient information" , -8L        , "Don't know / insufficient information"    ,
+  "Item not applicable"                   , -1L        , "Item not applicable"                      ,
+  "Single, never married / in CP"         ,  0L        , "Single, never married / in CP"            ,
+  "Married"                               ,  1L        , "Married / civil partner"                  ,
+  "Civil partner"                         ,  1L        , "Married / civil partner"                  ,
+  "Separated, still legally married"      ,  2L        , "Separated, still legally married / in CP" ,
+  "Separated, still legally in CP"        ,  2L        , "Separated, still legally married / in CP" ,
+  "Divorced"                              ,  3L        , "Divorced / former civil partner"          ,
+  "Former civil partner"                  ,  3L        , "Divorced / former civil partner"          ,
+  "Widowed"                               ,  4L        , "Widowed / surviving civil partner"        ,
+  "Surviving civil partner"               ,  4L        , "Widowed / surviving civil partner"
+)
+
+# Look up table for recoding partnr19_orig -> simple partnr19
+partnr19_simple_lookup <- tibble::tribble(
+  ~old_label                            , ~new_value , ~new_label                                 ,
+  "Script error"                        , -2L        , "Script error / information lost"          ,
+  "Respondent declined self completion" , -7L        , "Prefer not to say / declined"             ,
+  "Refused"                             , -9L        , "Refusal"                                  ,
+  "Not applicable"                      , -1L        , "Item not applicable"                      ,
+  "Don't know"                          , -8L        , "Don't know / insufficient information"    ,
+  "Single, that is never married"       ,  0L        , "Single, never married / in CP"            ,
+  "Married"                             ,  1L        , "Married / civil partner"                  ,
+  "Separated"                           ,  2L        , "Separated, still legally married / in CP" ,
+  "Divorced"                            ,  3L        , "Divorced / former civil partner"          ,
+  "Widowed"                             ,  4L        , "Widowed / surviving civil partner"
+)
+
+# Custom function to recode variables according to the look up table
+partnr_all <- partnr_all |>
+  mutate(
+    partnr19 = recode_labelled_by_labels(
+      partnr19_orig,
+      partnr19_simple_lookup,
+      na_to = -3,
+      na_label = "Not asked at the fieldwork stage/participated/interviewed"
+    ),
+    partnr25 = recode_labelled_by_labels(
+      partnradu25,
+      partnr_simple_lookup,
+      unmatched = "keep", # Keep any unmatched values & their labels, called to preserve -3 for NAs
+      na_to = -3,
+      na_label = "Not asked at the fieldwork stage/participated/interviewed"
+    ),
+    partnr32 = recode_labelled_by_labels(
+      partnradu32,
+      partnr_simple_lookup,
+      unmatched = "keep",
+      na_to = -3,
+      na_label = "Not asked at the fieldwork stage/participated/interviewed"
+    )
+  )
+
+# Checks
+partnr_all %>%
+  count(partnr19_orig, partnr19)
+
+partnr_all %>%
+  count(partnradu25, partnr25)
+
+partnr_all %>%
+  count(partnradu32, partnr32)
+
 partnr_all <- partnr_all %>%
-  mutate(
-    partnradu25 = case_when(
-      partnradu25 %in% 1:9 ~ partnradu25 - 1,
-      partnradu25 == -9 ~ -9,
-      partnradu25 == -8 ~ -8,
-      partnradu25 == -1 ~ -1,
-      TRUE ~ -3
-    ),
-    partnradu32 = case_when(
-      partnradu32 %in% 1:9 ~ partnradu32 - 1,
-      partnradu32 == -9 ~ -9,
-      partnradu32 == -8 ~ -8,
-      partnradu32 == -1 ~ -1,
-      TRUE ~ -3
-    )
-  ) %>%
-  mutate(
-    across(
-      c(partnr19, partnr25, partnr32),
-      ~ factor(
-        .x,
-        levels = c(0, 1, 2, 3, 4, -1, -3, -8, -9),
-        labels = c(
-          "Single and never married or in a CP",
-          "Married",
-          "Separated but still legally married/in a CP",
-          "Divorced/former CP",
-          "Widowed/surviving CP",
-          "Item not applicable",
-          "Not asked at the fieldwork stage/participated/interviewed",
-          "Don’t know/insufficient information",
-          "Refusal"
-        )
-      )
-    ),
-    across(
-      c(partnradu25, partnradu32),
-      ~ factor(
-        .x,
-        levels = c(0, 1, 2, 3, 4, 5, 6, 7, 8, -1, -3, -8, -9),
-        labels = c(
-          "Single and never married or in a CP",
-          "Married",
-          "Separated but still legally married",
-          "Divorced",
-          "Widowed",
-          "A civil partner",
-          "Separated but still legally in a CP",
-          "A former civil partner",
-          "A surviving civil partner",
-          "Item not applicable",
-          "Not asked at the fieldwork stage/participated/interviewed",
-          "Don’t know/insufficient information",
-          "Refusal"
-        )
-      )
-    )
-  ) %>%
   select(NSID, partnr19, partnr25, partnr32, partnradu25, partnradu32)
 
 # Region --------------------------------------------------------------------
@@ -504,7 +525,7 @@ region_vars <- list(
 # Merge all region variables by NSID
 region_all <- reduce(region_vars, full_join, by = "NSID")
 
-# recode missing valuse and response categories
+# Recode missing valuse and response categories
 region_all <- region_all %>%
   mutate(across(
     c(regub15, regub16),
@@ -524,21 +545,23 @@ region_all <- region_all %>%
     )
   )) %>%
 
-  mutate(across(
-    c(regor25, regor32),
-    ~ case_when(
-      .x %in% 1:12 ~ .x,
-      .x == 13 ~ -2, # faulty location
-      .x == -9 ~ -9, # refused
-      .x == -8 ~ -8, # don't know
-      .x == -1 ~ -1, # not applicable
-      TRUE ~ -3 # not participated
+  mutate(
+    across(
+      c(regor25, regor32),
+      ~ case_when(
+        .x %in% 1:12 ~ .x,
+        .x == 13 ~ -2, # faulty location
+        .x == -9 ~ -9, # refused
+        .x == -8 ~ -8, # don't know
+        .x == -1 ~ -1, # not applicable
+        TRUE ~ -3 # not participated
+      )
     )
-  )) %>%
+  ) %>%
 
   mutate(
     regint32 = case_when(
-      regint32 %in% c(1, 2, 3, 4) ~ 1, # in the UK
+      regint32 %in% 1:4 ~ 1, # in the UK
       regint32 == 5 ~ 2, # abroad
       regint32 == -9 ~ -9,
       regint32 == -8 ~ -8,
@@ -550,87 +573,83 @@ region_all <- region_all %>%
   mutate(
     across(
       c(regub15, regub16),
-      ~ factor(
-        .x,
-        levels = c(1, 2, 3, 4, 5, 6, 7, 8, -1, -2, -3, -7, -8, -9),
+      ~ labelled(
+        x = .x,
         labels = c(
-          "Urban >=10k – sparse",
-          "Town & Fringe – sparse",
-          "Village – sparse",
-          "Hamlet and Isolated Dwelling – sparse",
-          "Urban >= 10k - less sparse",
-          "Town & Fringe - less sparse",
-          "Village - less sparse",
-          "Hamlet and Isolated Dwelling - less sparse",
-          "Item not applicable",
-          "Script error/information lost",
-          "Not asked at the fieldwork stage/participated/interviewed",
-          "Prefer not to say",
-          "Don’t know/insufficient information",
-          "Refusal"
+          "Urban >=10k – sparse" = 1,
+          "Town & Fringe – sparse" = 2,
+          "Village – sparse" = 3,
+          "Hamlet and Isolated Dwelling – sparse" = 4,
+          "Urban >= 10k - less sparse" = 5,
+          "Town & Fringe - less sparse" = 6,
+          "Village - less sparse" = 7,
+          "Hamlet and Isolated Dwelling - less sparse" = 8,
+          "Item not applicable" = -1,
+          "Script error/information lost" = -2,
+          "Not asked at the fieldwork stage/participated/interviewed" = -3,
+          "Prefer not to say" = -7,
+          "Don’t know/insufficient information" = -8,
+          "Refusal" = -9
         )
       )
     ),
     across(
       c(regov15, regov16),
-      ~ factor(
-        .x,
-        levels = c(1, 2, 3, 4, 5, 6, 7, 8, 9, -1, -2, -3, -7, -8, -9),
+      ~ labelled(
+        x = .x,
         labels = c(
-          "North East",
-          "North West",
-          "Yorkshire and The Humber",
-          "East Midlands",
-          "West Midlands",
-          "East of England",
-          "London",
-          "South East",
-          "South West",
-          "Item not applicable",
-          "Script error/information lost",
-          "Not asked at the fieldwork stage/participated/interviewed",
-          "Prefer not to say",
-          "Don’t know/insufficient information",
-          "Refusal"
+          "North East" = 1,
+          "North West" = 2,
+          "Yorkshire and The Humber" = 3,
+          "East Midlands" = 4,
+          "West Midlands" = 5,
+          "East of England" = 6,
+          "London" = 7,
+          "South East" = 8,
+          "South West" = 9,
+          "Item not applicable" = -1,
+          "Script error/information lost" = -2,
+          "Not asked at the fieldwork stage/participated/interviewed" = -3,
+          "Prefer not to say" = -7,
+          "Don’t know/insufficient information" = -8,
+          "Refusal" = -9
         )
       )
     ),
     across(
       c(regor25, regor32),
-      ~ factor(
-        .x,
-        levels = c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, -1, -2, -3, -8, -9),
+      ~ labelled(
+        x = .x,
         labels = c(
-          "North East",
-          "North West",
-          "Yorkshire and The Humber",
-          "East Midlands",
-          "West Midlands",
-          "East of England",
-          "London",
-          "South East",
-          "South West",
-          "Wales",
-          "Scotland",
-          "Northern Ireland",
-          "Item not applicable",
-          "Script error/information lost",
-          "Not asked at the fieldwork stage/participated/interviewed",
-          "Don’t know/insufficient information",
-          "Refusal"
+          "North East" = 1,
+          "North West" = 2,
+          "Yorkshire and The Humber" = 3,
+          "East Midlands" = 4,
+          "West Midlands" = 5,
+          "East of England" = 6,
+          "London" = 7,
+          "South East" = 8,
+          "South West" = 9,
+          "Wales" = 10,
+          "Scotland" = 11,
+          "Northern Ireland" = 12,
+          "Item not applicable" = -1,
+          "Script error/information lost" = -2,
+          "Not asked at the fieldwork stage/participated/interviewed" = -3,
+          "Don’t know/insufficient information" = -8,
+          "Refusal" = -9
         )
       )
     ),
-    regint32 = factor(
-      regint32,
-      levels = c(1, 2, -1, -3, -8, -9),
+    regint32 = labelled(
+      x = regint32,
       labels = c(
-        "In the UK",
-        "Abroad",
-        "Item not applicable",
-        "Not asked at the fieldwork stage/participated/interviewed",
-        "Don’t know/insufficient information",
-        "Refusal"
+        "In the UK" = 1,
+        "Abroad" = 2,
+        "Item not applicable" = -1,
+        "Not asked at the fieldwork stage/participated/interviewed" = -3,
+        "Don’t know/insufficient information" = -8,
+        "Refusal" = -9
       )
     )
   ) %>%

--- a/R/01-demographic.R
+++ b/R/01-demographic.R
@@ -307,7 +307,7 @@ sexuality_all <- sexuality_all %>%
       sori20 == 2 ~ 2,
       sori20 == 3 ~ 3,
       sori20 == 4 ~ 4,
-      sori20 == -3 ~ -3, # Check: 100 stands for 'Respondent declined sexual experience Qs', -97: Refused self-completion, this maps them onto 'Not asked (...)' instead of 'Refused'
+      sori20 == -3 ~ -3,
       sori20 %in% c(-92, -9, -100, -97) ~ -9,
       sori20 %in% c(-1, -8) ~ -8,
       sori20 == -91 ~ -1, # Not applicable


### PR DESCRIPTION
**Fixes**
- **Ethnicity:** Changed the mapping for code -94 from "Script error/information lost" to "Don't know/insufficient information" (now coded as -8) to reflect the documentation.
- **Sexual orientation:** 
  - For S6 and S7 (sori19, sori20), codes -100 and -97 (declined sexual experience questions / refused self-completion) now map to -9 (“Refusal”) rather than -3.
  - Code -91 is now consistently treated as -1 (“Item not applicable”) instead of -8 (“Don’t know / insufficient information”).
  - For S8 (sori25), code -1 (“Not applicable”) is now kept as -1 (“Item not applicable”) instead of being merged into -8 ("Don't know/insufficient information").
  - For S9 (sori32), code 5 (“Prefer not to say”) is now mapped to -7 ("Prefer not to say"), which is consistent with documentation. Code -1 is now kept as “Item not applicable” rather than merged into -8 ("Don't know/insufficient information").
- **Partnership status:** Re-written using look-up tables to make the mapping very explicit. This was needed because the source variables are inconsistent in values/labels, so some substantive and missing categories were getting remapped incorrectly. I have also added cross-checks for the derived variables. 

**Improvements**
- All derived variables now stored as `haven::labelled` rather than factors, so that values/labels match the documentation. 
- Removed redundant `is.na()` checks and simplified some `case_when()` logic.
