### PR TITLE
Code review: 05-anthropometric.R

### DIFF
--- a/R/05-anthropometric.R
+++ b/R/05-anthropometric.R
@@ -8,68 +8,84 @@
 # or manually run 00-load-raw-data.R before this script.
 
 # Weight --------------------------------------------------------------------
-
 # Load weight variables from each sweep
 wt_vars <- list(
   S1 = ns_data[["S12history"]] %>%
-    select(NSID, wt0 = bwtkg),
+    select(NSID, wt0_s1 = bwtkg),
   S4 = ns_data[["S4history"]] %>%
-    select(NSID, wt0 = W4bwtkgYP),
+    select(NSID, wt0_s4 = W4bwtkgYP),
   S8 = ns_data[["S8maininterview"]] %>%
-    select(NSID, wt25 = W8WEIGHT),
+    select(NSID, wt25_raw = W8WEIGHT),
   S9 = ns_data[["S9maininterview"]] %>%
-    select(NSID, wt32 = W9WEIGHT)
+    select(NSID, wt32_raw = W9WEIGHT)
 )
 
 # Merge datasets
 wt_all <- reduce(wt_vars, full_join, by = "NSID")
 
 # Harmonise weight variables
-wt_all <- wt_all %>%
-  mutate(
-    wt0 = coalesce(as.numeric(wt0.x), as.numeric(wt0.y))
-  ) %>%
-  select(-wt0.x, -wt0.y) %>%
+wt_rec <- wt_all %>%
   mutate(
     wt0 = case_when(
-      wt0 > 0 ~ wt0,
-      wt0 == -92 ~ -9,
-      wt0 == -91 ~ -1,
-      wt0 == -1 ~ -8,
-      wt0 %in% c(-996, -99) ~ -3,
-      is.na(wt0) ~ -3,
-      TRUE ~ -2
+      wt0_s1 > 0 ~ as.numeric(wt0_s1),
+      # Note: wt0_s4 has no substantive values when wt0_s1 < 0,
+      # so it is only needed when wt0_s1 is NA.
+      is.na(wt0_s1) & wt0_s4 > 0 ~ as.numeric(wt0_s4),
+      # If both are missing, follow this logic for missing values:
+      # If either has dk (-1) or insufficient information (-94), make wt0 dk/insufficient info (-8)
+      wt0_s1 %in% c(-1, -94) | wt0_s4 == -94 ~ -8,
+      # If either has 'not applicable' (-91), make wt0 'not applicable' (-1)
+      wt0_s1 == -91 | wt0_s4 == -91 ~ -1,
+      # All other options should default to -3 (not interviewed or similar)
+      .default = -3
     ),
     wt25 = case_when(
-      wt25 > 0 ~ wt25,
-      wt25 == -9 ~ -9,
-      wt25 == -8 ~ -8,
-      wt25 == -1 ~ -1,
-      is.na(wt25) ~ -3,
+      wt25_raw > 0 ~ wt25_raw,
+      wt25_raw == -9 ~ -9,
+      wt25_raw == -8 ~ -8,
+      wt25_raw == -1 ~ -1,
+      is.na(wt25_raw) ~ -3,
       TRUE ~ -2
     ),
     wt32 = case_when(
-      wt32 > 0 ~ wt32,
-      wt32 == -9 ~ -9,
-      wt32 == -8 ~ -8,
-      wt32 == -1 ~ -1,
-      is.na(wt32) ~ -3,
+      wt32_raw > 0 ~ wt32_raw,
+      wt32_raw == -9 ~ -9,
+      wt32_raw == -8 ~ -8,
+      wt32_raw == -1 ~ -1,
+      is.na(wt32_raw) ~ -3,
       TRUE ~ -2
     )
   ) %>%
-  mutate(across(
-    c(wt0, wt25, wt32),
-    ~ labelled(
-      .x,
-      labels = c(
-        "Item not applicable" = -1,
-        "Script error/information lost" = -2,
-        "Not asked at the fieldwork stage/participated/interviewed" = -3,
-        "Don’t know/insufficient information" = -8,
-        "Refusal" = -9
+  mutate(
+    across(
+      c(wt0, wt25, wt32),
+      ~ labelled(
+        .x,
+        labels = c(
+          "Item not applicable" = -1,
+          "Script error/information lost" = -2,
+          "Not asked at the fieldwork stage/participated/interviewed" = -3,
+          "Don’t know/insufficient information" = -8,
+          "Refusal" = -9
+        )
       )
     )
-  )) %>%
+  )
+
+# Cross-checks (missing values)
+wt_rec %>%
+  filter(wt0_s1 < 0 | wt0_s4 < 0) %>%
+  count(wt0_s1, wt0_s4, wt0)
+
+wt_rec %>%
+  filter(wt25_raw < 0 | is.na(wt25_raw)) %>%
+  count(wt25_raw, wt25)
+
+wt_rec %>%
+  filter(wt32_raw < 0 | is.na(wt32_raw)) %>%
+  count(wt32_raw, wt32)
+
+wt_all <- wt_rec %>%
   select(NSID, wt0, wt25, wt32)
 
 # Height --------------------------------------------------------------------
@@ -80,29 +96,29 @@ ht_vars <- list(
   S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
   S8 = ns_data[["S8maininterview"]] %>%
-    select(NSID, ht25 = W8HEIGHT),
+    select(NSID, ht25_raw = W8HEIGHT),
   S9 = ns_data[["S9maininterview"]] %>%
-    select(NSID, ht32 = W9HEIGHT)
+    select(NSID, ht32_raw = W9HEIGHT)
 )
 
 # Merge datasets
 ht_all <- reduce(ht_vars, full_join, by = "NSID")
 
 # Recode height
-ht_all <- ht_all %>%
+ht_rec <- ht_all %>%
   mutate(
     ht25 = case_when(
-      ht25 > 0 ~ ht25,
-      ht25 == -9 ~ -9,
-      ht25 == -8 ~ -8,
-      ht25 == -1 ~ -1,
+      ht25_raw > 0 ~ ht25_raw,
+      ht25_raw == -9 ~ -9,
+      ht25_raw == -8 ~ -8,
+      ht25_raw == -1 ~ -1,
       TRUE ~ -3
     ),
     ht32 = case_when(
-      ht32 > 0 ~ ht32,
-      ht32 == -9 ~ -9,
-      ht32 == -8 ~ -8,
-      ht32 == -1 ~ -1,
+      ht32_raw > 0 ~ ht32_raw,
+      ht32_raw == -9 ~ -9,
+      ht32_raw == -8 ~ -8,
+      ht32_raw == -1 ~ -1,
       TRUE ~ -3
     ),
     # combined height variable using most recent valid data
@@ -126,7 +142,28 @@ ht_all <- ht_all %>%
         "Refusal" = -9
       )
     )
-  )) %>%
+  ))
+
+# Checks
+ht_rec %>%
+  filter(ht25_raw < 0 | is.na(ht25_raw) | ht25 < 0 | is.na(ht25)) %>%
+  count(ht25_raw, ht25)
+
+ht_rec %>%
+  filter(ht32_raw < 0 | is.na(ht32_raw) | ht32 < 0 | is.na(ht32)) %>%
+  count(ht32_raw, ht32)
+
+ht_rec %>%
+  filter(
+    (ht25 < 0 &
+      ht32 < 0) |
+      ht25_32 < 0 |
+      is.na(ht25_32) |
+      (is.na(ht25) & is.na(ht32))
+  ) %>%
+  count(ht25, ht32, ht25_32)
+
+ht_all <- ht_rec %>%
   select(NSID, ht25, ht32, ht25_32)
 
 # BMI --------------------------------------------------------------------
@@ -137,29 +174,29 @@ bmi_vars <- list(
   S4 = ns_data[["S4youngperson"]] %>%
     select(NSID),
   S8 = ns_data[["S8derivedvariable"]] %>%
-    select(NSID, bmi25 = W8DBMI),
+    select(NSID, bmi25_raw = W8DBMI),
   S9 = ns_data[["S9derivedvariable"]] %>%
-    select(NSID, bmi32 = W9DBMI)
+    select(NSID, bmi32_raw = W9DBMI)
 )
 
 # Merge all BMI data by NSID
 bmi_all <- reduce(bmi_vars, full_join, by = "NSID")
 
 # Recode BMI variables
-bmi_all <- bmi_all %>%
+bmi_rec <- bmi_all %>%
   mutate(
     bmi25 = case_when(
-      bmi25 > 0 ~ bmi25,
-      bmi25 == -9 ~ -9,
-      bmi25 == -8 ~ -8,
-      bmi25 == -1 ~ -1,
+      bmi25_raw > 0 ~ bmi25_raw,
+      bmi25_raw == -9 ~ -9,
+      bmi25_raw == -8 ~ -8,
+      bmi25_raw == -1 ~ -1,
       TRUE ~ -3
     ),
     bmi32 = case_when(
-      bmi32 > 0 ~ bmi32,
-      bmi32 == -9 ~ -9,
-      bmi32 == -8 ~ -8,
-      bmi32 == -1 ~ -1,
+      bmi32_raw > 0 ~ bmi32_raw,
+      bmi32_raw == -9 ~ -9,
+      bmi32_raw == -8 ~ -8,
+      bmi32_raw == -1 ~ -1,
       TRUE ~ -3
     )
   ) %>%
@@ -175,5 +212,15 @@ bmi_all <- bmi_all %>%
         "Refusal" = -9
       )
     )
-  )) %>%
+  ))
+
+bmi_rec %>%
+  filter(bmi25_raw < 0 | is.na(bmi25_raw) | bmi25 < 0 | is.na(bmi25)) %>%
+  count(bmi25_raw, bmi25)
+
+bmi_rec %>%
+  filter(bmi32_raw < 0 | is.na(bmi32_raw) | bmi32 < 0 | is.na(bmi32)) %>%
+  count(bmi32_raw, bmi32)
+
+bmi_all <- bmi_rec %>%
   select(NSID, bmi25, bmi32)


### PR DESCRIPTION
## Fixes

**Weight** (`wt0`)
- Fixed missing value re-codes in the old scheme. 
- Amended the missing value re-coding scheme itself to derive missing values based on codes in both `wt0` from `s1` and `s4` (see comments in the code for details).

## Improvements

**General**
- Raw inputs are retained with a _raw suffix.
- Derived variables are now stored as ``haven::labelled`` vectors.
- Added cross-tab checks.